### PR TITLE
Add missing base sensor.Sensor class

### DIFF
--- a/components/vindriktning/sensor.py
+++ b/components/vindriktning/sensor.py
@@ -13,7 +13,9 @@ from esphome.const import (
 DEPENDENCIES = ["uart"]
 
 vindriktning_ns = cg.esphome_ns.namespace("vindriktning")
-VindriktningComponent = vindriktning_ns.class_("VindriktningComponent", uart.UARTDevice, cg.Component)
+VindriktningComponent = vindriktning_ns.class_("VindriktningComponent",
+                                               uart.UARTDevice, cg.Component,
+                                               sensor.Sensor)
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(


### PR DESCRIPTION
Without `sensor.Sensor` base class created object is not sensor according to Python code.